### PR TITLE
fix: update .goreleaser.yml configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 ---
+version: 2
 before:
   hooks:
     - go mod tidy
@@ -20,14 +21,12 @@ builds:
 checksum:
   name_template: "checksums.txt"
 archives:
-  - builds:
+  - ids:
       - kubectl-janitor
     name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
     wrap_in_directory: false
     files:
       - LICENSE
-source:
-  rlcp: true
 
 krews:
   - name: kubectl-janitor


### PR DESCRIPTION
- Added version 2 to the configuration.
- Updated archives section to use ids instead of builds.
- Removed source section with rlcp setting.